### PR TITLE
Lanzar sincronizción con UCRM y Contabilium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ group :development, :test do
   gem 'rspec-rails'
 end
 
+group :test do
+  gem 'rspec-sidekiq'
+end
+
 group :development do
   # Access an interactive console on exception pages or by calling 'console'
   # anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,9 @@ GEM
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
+    rspec-sidekiq (3.0.3)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
@@ -381,6 +384,7 @@ DEPENDENCIES
   rails_real_favicon
   ransack
   rspec-rails
+  rspec-sidekiq
   selenium-webdriver
   sentry-raven
   sidekiq

--- a/app/jobs/ucrm/client_add_job.rb
+++ b/app/jobs/ucrm/client_add_job.rb
@@ -4,6 +4,9 @@
 # la API de UCRM y de crearlo localmente. Este job se dispara en respuesta a
 # una notificación desde UCRM con el evento "client.add".
 #
+# También encola un Contab::ClientCreateJob para crear el cliente en
+# Contabilium.
+#
 class UCRM::ClientAddJob
   include Sidekiq::Worker
 
@@ -20,6 +23,7 @@ class UCRM::ClientAddJob
 
     if c.save
       webhook.completed!
+      Contab::ClientCreateJob.perform_async(c.id)
     else
       webhook.error!(c.errors.messages.to_json)
     end

--- a/spec/jobs/ucrm/client_edit_spec.rb
+++ b/spec/jobs/ucrm/client_edit_spec.rb
@@ -28,6 +28,8 @@ context 'UCRM sends a notification event' do
     new_attrs = client_new.attributes_for_ucrm_update
 
     expect(old_attrs).to eq(new_attrs)
+
+    expect(Contab::ClientEditJob).to have_enqueued_sidekiq_job(client_old.id)
   end
 
   example 'client edit hook fails with error' do
@@ -50,6 +52,8 @@ context 'UCRM sends a notification event' do
     expect(old_attrs).to eq(new_attrs)
 
     expect(webhook.error_msg).to_not be_blank
+
+    expect(Contab::ClientEditJob).to_not have_enqueued_sidekiq_job
   end
 
   example 'the edited client does not exist in maxwell' do
@@ -66,5 +70,7 @@ context 'UCRM sends a notification event' do
 
     expect(webhook.error_msg).to_not be_blank
     expect(Client.find_by(ucrm_id: webhook.entity_id)).to be_nil
+
+    expect(Contab::ClientEditJob).to_not have_enqueued_sidekiq_job
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,4 +101,12 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
 
   config.include ClientsHelper
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+end
+
+RSpec::Sidekiq.configure do |config|
+  config.warn_when_jobs_not_processed_by_sidekiq = false
 end


### PR DESCRIPTION
* Lanzar sincronización con UCRM y Contabilium al crear / editar
clientes localmente. (Maxwell -> UCRM, Contabilium).
* Lanzar sincronización al recibir un evento desde UCRM
(UCRM -> Maxwell -> Contabilium).
* Agregados casos de prueba para verificar que se lancen los trabajos.
* Agregado caso de prueba para edición de clientes.